### PR TITLE
Add product flag to cluster.js to allow for overriding

### DIFF
--- a/scripts/cluster.js
+++ b/scripts/cluster.js
@@ -74,6 +74,10 @@ const localCryptoUtil = require('../lib/localCryptoUtil');
                         'IP address for config sync.'
                     )
                     .option(
+                        '--product <product>',
+                        'Explicitly specify the product we are running on (BIG-IP|BIG-IQ)'
+                    )
+                    .option(
                         '--big-iq-failover-peer-ip <peer_ip>',
                         'If configuring a BIG-IQ failover primary, this is the management IP address for the secondary'
                     )
@@ -343,6 +347,7 @@ const localCryptoUtil = require('../lib/localCryptoUtil');
                                 port: options.port,
                                 passwordIsUrl: typeof options.passwordUrl !== 'undefined',
                                 passwordEncrypted: options.passwordEncrypted,
+                                product: options.product,
                                 clOptions: providerOptions
                             }
                         );


### PR DESCRIPTION
This PR adds the `product` flag which can optionally be set and passed into the BIGIP `init()` call.  Without this ability, the check for the product type would rely on a `grep` invocation on the main config.  Unfortunately, if your devices' hostnames contain the string "product", this would fail and the script would do nothing.