### PR TITLE
deviceInfo hostMac is not always populated when cloud-libs onboarding…

### DIFF
--- a/lib/bigIpOnboard.js
+++ b/lib/bigIpOnboard.js
@@ -457,7 +457,7 @@ BigIpOnboard.prototype.revokeLicenseViaBigIq = function revokeLicenseViaBigIq(
         .then((deviceInfo) => {
             instance.setHostname(deviceInfo.hostname);
             instance.setMachineId(deviceInfo.machineId);
-            instance.setMacAddress(deviceInfo.hostMac);
+            instance.setMacAddress(deviceInfo.baseMac);
             instance.setMgmtIp(deviceInfo.managementAddress);
             return bigIq.init(
                 host,

--- a/lib/bigIq54LicenseProvider.js
+++ b/lib/bigIq54LicenseProvider.js
@@ -181,7 +181,7 @@ function licenseFromPool(bigIqControl, poolName, bigIpMgmtAddress, options) {
                         assignmentType: 'UNREACHABLE',
                         tenant: `{"hostname":"${deviceInfo.hostname}",
                         "mgmtAddress":"${deviceInfo.managementAddress}"}`,
-                        macAddress: deviceInfo.hostMac
+                        macAddress: deviceInfo.baseMac
                     }
                 );
             };

--- a/scripts/autoscale.js
+++ b/scripts/autoscale.js
@@ -404,7 +404,7 @@ const BACKUP = require('../lib/sharedConstants').BACKUP;
                     })
                     .then((response) => {
                         this.instance.machineId = response.machineId; // we need this for revoke on BIG-IQ 5.3
-                        this.instance.macAddress = response.hostMac; // we need this for revoke on BIG-IQ 5.4
+                        this.instance.macAddress = response.baseMac; // we need this for revoke on BIG-IQ 5.4
                         this.instance.version = response.version;
                         markVersions(this.instances);
                         return cloudProvider.putInstance(this.instanceId, this.instance);

--- a/test/lib/bigIpOnboardTests.js
+++ b/test/lib/bigIpOnboardTests.js
@@ -789,7 +789,7 @@ module.exports = {
         testBasic(test) {
             const hostname = 'myHostname';
             const machineId = 'myMachineId';
-            const hostMac = 'myMacAddress';
+            const baseMac = 'myMacAddress';
             const poolName = 'myPoolName';
 
             icontrolMock.when(
@@ -798,7 +798,7 @@ module.exports = {
                 {
                     hostname,
                     machineId,
-                    hostMac
+                    baseMac
                 }
             );
 
@@ -808,7 +808,7 @@ module.exports = {
                     test.strictEqual(poolNameSent, poolName);
                     test.strictEqual(instanceSent.hostname, hostname);
                     test.strictEqual(instanceSent.machineId, machineId);
-                    test.strictEqual(instanceSent.macAddress, hostMac);
+                    test.strictEqual(instanceSent.macAddress, baseMac);
                 })
                 .catch((err) => {
                     test.ok(false, err);


### PR DESCRIPTION
For TMOS VE license activation with BIG-IQ, deviceInfo.baseMac should be use as it is always populated. Using deviceInfo.hostMac is not always populated. For BIG-IQ licensing of BIG-IP VE, these values should be the same.