### PR TITLE
add option to use jmespath

### DIFF
--- a/lib/genericNodeProvider.js
+++ b/lib/genericNodeProvider.js
@@ -18,6 +18,7 @@
 
 const util = require('util');
 const q = require('q');
+const jmespath = require('jmespath');
 
 const CloudProvider = require('./cloudProvider');
 const Logger = require('./logger');
@@ -106,6 +107,9 @@ GenericNodeProvider.prototype.init = function init(providerOptions, options) {
     this.initOptions = options || {};
     this.providerOptions = providerOptions || {};
 
+    if (this.providerOptions.jmesPathQuery) {
+        return q();
+    }
     if (typeof this.providerOptions.propertyPathId !== 'string') {
         return q.reject(new Error('ProviderOptions.propertyPathId required to fetch node data'));
     }
@@ -164,7 +168,9 @@ GenericNodeProvider.prototype.getNodesFromUri = function getNodesFromUri(uri, op
             if (!Array.isArray(resData)) {
                 return q.reject(new Error('Data must be a JSON array of objects.'));
             }
-
+            if (this.providerOptions.jmesPathQuery) {
+                return q(jmespath.search(resData, this.providerOptions.jmesPathQuery));
+            }
             for (let i = 0; i < resData.length; i++) {
                 const node = { ip: {} };
                 node.id = getDataFromPropPath(this.propertyPaths.propertyPathId, resData[i]);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "commander": "^2.19.0",
+    "jmespath": "^0.15.0",
     "q": "^1.5.1",
     "uuid5": "^1.0.2",
     "winston": "^2.4.4"

--- a/test/lib/genericNodeProviderTests.js
+++ b/test/lib/genericNodeProviderTests.js
@@ -33,6 +33,10 @@ let providerOptions = {
 };
 providerOptions = Object.assign(providerOptions, propertyPaths);
 
+const providerJmesPathOptions = {
+    jmesPathQuery: '[*].{id:node.uuid,ip:{private:node.ips[0],public:node.ips[1]}}'
+};
+
 const initOptions = {
     bar: 'foo',
     world: 'hello'
@@ -289,6 +293,40 @@ module.exports = {
 
             test.expect(globalTests + 1);
             testProvider.init(providerOptions)
+                .then(() => {
+                    return testProvider.getNodesFromUri(targetUrl, targetOptions)
+                        .then((results) => {
+                            test.deepEqual(results, [
+                                {
+                                    id: 'b10b5485-d6f1-47c2-9153-831dda8e1467',
+                                    ip: {
+                                        public: '10.10.0.10',
+                                        private: '192.168.0.140'
+                                    }
+                                },
+                                {
+                                    id: '4cd3e814-09b1-4ea6-88f5-9524d45c1eda',
+                                    ip: {
+                                        public: '11.11.0.11',
+                                        private: '192.168.0.141'
+                                    }
+                                }
+                            ]);
+                        });
+                })
+                .catch((err) => {
+                    test.ok(false, err);
+                })
+                .finally(() => {
+                    test.done();
+                });
+        },
+
+        testJmesPathJsonArrayNodes(test) {
+            mockGetDataFromUrl(test, responseNodeData);
+
+            test.expect(globalTests + 1);
+            testProvider.init(providerJmesPathOptions)
                 .then(() => {
                     return testProvider.getNodesFromUri(targetUrl, targetOptions)
                         .then((results) => {


### PR DESCRIPTION
add new option "jmesPathQuery" to use jmespath to parse JSON
this makes it much easier to handle providers that may have different output and/or users that want to fetch different attributes (requires additional changes in other providers like f5-cloud-libs-consul)